### PR TITLE
fix(api): Tags is required at the definition level not the API object…

### DIFF
--- a/src/main/java/io/gravitee/repository/management/model/Api.java
+++ b/src/main/java/io/gravitee/repository/management/model/Api.java
@@ -199,14 +199,6 @@ public class Api {
         this.views = views;
     }
 
-    public Set<String> getTags() {
-        return tags;
-    }
-
-    public void setTags(Set<String> tags) {
-        this.tags = tags;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;


### PR DESCRIPTION
… itself

Closes gravitee-io/issues#581